### PR TITLE
feat: delete WP Rainbow options if plugin is uninstalled gh-9

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Uninstall logic for WP Rainbow
+ *
+ * @package WP_Rainbow
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	die;
+}
+
+$wp_rainbow_option_name = 'wp_rainbow_options';
+
+delete_option( $wp_rainbow_option_name );
+
+delete_site_option( $wp_rainbow_option_name );


### PR DESCRIPTION
See https://github.com/davisshaver/wp-rainbow/issues/9.